### PR TITLE
Suppress warnings from imagecreatefromstring

### DIFF
--- a/src/ImageComparator.php
+++ b/src/ImageComparator.php
@@ -272,7 +272,7 @@ class ImageComparator
             throw new ImageResourceException('Could not create an image resource from file');
         }
 
-        return imagecreatefromstring($imageData);
+        return @imagecreatefromstring($imageData);
     }
 
     /**


### PR DESCRIPTION
`imagecreatefromstring` handles warnings as errors, and throws exceptions that wouldn't impact creating images.

For example:
`imagecreatefromstring(): gd-png: libpng warning: iCCP: known incorrect sRGB profile`

This is a warning, and creating images work fine when the warning is ignored.

This pull request suppresses those warnings so they don't cause unnecessarily failures.